### PR TITLE
Pull out marathon endpopint to an env. var.

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -65,7 +65,8 @@ func adapter(c martini.Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func ListenAndServe(theAdapter PanamaxAdapter) {
-        adapterInstance = theAdapter
+	adapterInstance = theAdapter
+	log.Printf("Adapter service running at localhost:8001")
 	err := http.ListenAndServe(":8001", mServer)
 	if	err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -1,11 +1,18 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"github.com/CenturyLinkLabs/panamax-marathon-adapter/api"
 	"github.com/CenturyLinkLabs/panamax-marathon-adapter/marathon"
 )
 
 func main() {
-	marathonAdapter := marathon.NewMarathonAdapter("http://10.141.141.10:8080")
+	var endpoint = ""
+	if endpoint = os.Getenv("MARATHON_ENDPOINT"); endpoint == "" {
+		fmt.Println("Error: Invalid endpoint url. Set env. var. 'MARATHON_ENDPOINT' correctly. ")
+		os.Exit(1)
+	}
+	marathonAdapter := marathon.NewMarathonAdapter(endpoint)
 	api.ListenAndServe(marathonAdapter)
 }

--- a/marathon/adapter.go
+++ b/marathon/adapter.go
@@ -11,7 +11,7 @@ func newClient(endpoint string) *gomarathon.Client {
 	if endpoint != "" {
 		url = endpoint
 	}
-	log.Printf("Marathon API: %s", url)
+	log.Printf("Marathon Endpoint: %s", url)
 	c, err := gomarathon.NewClient(url, nil)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This will help us access our Marathon endpoint in our own Mesos setup.
