### PR TITLE
Adding command line flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,11 +5,22 @@ import (
 	"github.com/centurylinklabs/panamax-marathon-adapter/api"
 	"github.com/centurylinklabs/panamax-marathon-adapter/marathon"
 	"os"
+	"flag"
 )
 
 func main() {
-	var endpoint = ""
-	if endpoint = os.Getenv("MARATHON_ENDPOINT"); endpoint == "" {
+	//set up command line flag
+	var cmd_endpoint string
+	flag.StringVar(&cmd_endpoint, "endpoint", "", "Marathon Endpoint")
+
+	endpoint := os.Getenv("MARATHON_ENDPOINT");
+
+	if endpoint == "" {
+		flag.Parse();
+		endpoint = cmd_endpoint;
+	}
+
+	if  endpoint == "" {
 		fmt.Println("Error: Invalid endpoint url. Set env. var. 'MARATHON_ENDPOINT' correctly. ")
 		os.Exit(1)
 	}


### PR DESCRIPTION
The env var MARATHON_ENDPOINT will be default, but if it's blank we'll check for the -endpoint flag.
