### PR TITLE
Use golang-builder for packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,5 @@
-# Start from a Debian image with the latest version of Go installed
-# and a workspace (GOPATH) configured at /go.
-FROM golang
-
-# Copy the local package files to the container's workspace.
-ADD . /go/src/github.com/centurylinklabs/panamax-marathon-adapter
-
-# Build dependencies
-RUN go get github.com/codegangsta/martini
-RUN go get github.com/jbdalido/gomarathon
-RUN go get github.com/satori/go.uuid
-
-# Build adapter
-RUN go install github.com/centurylinklabs/panamax-marathon-adapter
-
-# Run the adapter
-ENTRYPOINT /go/bin/panamax-marathon-adapter
-
+FROM scratch
+MAINTAINER CenturyLink Labs <clt-labs-futuretech@centurylink.com>
+EXPOSE 8001
+COPY panamax-marathon-adapter /
+ENTRYPOINT ["/panamax-marathon-adapter"]

--- a/api/server.go
+++ b/api/server.go
@@ -1,4 +1,4 @@
-package api
+package api // import "github.com/CenturyLinkLabs/panamax-marathon-adapter/api"
 
 import (
 	"fmt"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+docker run --rm \
+  -v $(pwd):/src \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  centurylink/golang-builder:latest \
+  centurylink/panamax-marathon-adapter:latest

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
-package main
+package main // import "github.com/CenturyLinkLabs/panamax-marathon-adapter"
 
 import (
 	"fmt"
-	"github.com/centurylinklabs/panamax-marathon-adapter/api"
-	"github.com/centurylinklabs/panamax-marathon-adapter/marathon"
+	"github.com/CenturyLinkLabs/panamax-marathon-adapter/api"
+	"github.com/CenturyLinkLabs/panamax-marathon-adapter/marathon"
 	"os"
 )
 

--- a/marathon/adapter.go
+++ b/marathon/adapter.go
@@ -1,12 +1,12 @@
-package marathon
+package marathon // import "github.com/CenturyLinkLabs/panamax-marathon-adapter/marathon"
 
 import (
 	"log"
 	"fmt"
 	"strings"
 
-	"github.com/centurylinklabs/panamax-marathon-adapter/api"
-	"github.com/jbdalido/gomarathon"
+	"github.com/CenturyLinkLabs/gomarathon"
+	"github.com/CenturyLinkLabs/panamax-marathon-adapter/api"
 	"github.com/satori/go.uuid"
 )
 

--- a/marathon/adapter_test.go
+++ b/marathon/adapter_test.go
@@ -1,7 +1,7 @@
 package marathon
 
 import (
-	"github.com/centurylinklabs/panamax-marathon-adapter/api"
+	"github.com/CenturyLinkLabs/panamax-marathon-adapter/api"
 	"github.com/jbdalido/gomarathon"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/marathon/transformers.go
+++ b/marathon/transformers.go
@@ -3,8 +3,8 @@ package marathon
 import (
 	"strings"
 
-	"github.com/centurylinklabs/panamax-marathon-adapter/api"
-	"github.com/jbdalido/gomarathon"
+	"github.com/CenturyLinkLabs/gomarathon"
+	"github.com/CenturyLinkLabs/panamax-marathon-adapter/api"
 )
 
 type PanamaxServiceConverter interface {

--- a/marathon/transformers_test.go
+++ b/marathon/transformers_test.go
@@ -1,7 +1,7 @@
 package marathon
 
 import (
-	"github.com/centurylinklabs/panamax-marathon-adapter/api"
+	"github.com/CenturyLinkLabs/panamax-marathon-adapter/api"
 	"github.com/jbdalido/gomarathon"
 	"github.com/stretchr/testify/assert"
 	"testing"


### PR DESCRIPTION
Re-jiggering some of the code so that it's compatible with the `golang-builder`. The end result is that the Docker image used to package the binary should be a fraction of the size of the original one.

Other changes made:
- Added canonical import path comments to the package statements (feature of Go 1.4 that assists with the compilation process)
- Switched `centurylinklabs` in the package names to `CenturyLinkLabs` (just for consistency with other CTL projects)
- Changed the import of the `gomarathon` code to reference our fork to work-around compilation errors when trying to build against the jbdalido version
