### PR TITLE
shorten group name

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "github.com/centurylinklabs/panamax-marathon-adapter",
+	"ImportPath": "github.com/CenturyLinkLabs/panamax-marathon-adapter",
 	"GoVersion": "go1.3",
 	"Deps": [
 		{

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,10 +1,18 @@
 {
-	"ImportPath": "github.com/CenturyLinkLabs/panamax-marathon-adapter",
-	"GoVersion": "go1.3.2",
+	"ImportPath": "github.com/centurylinklabs/panamax-marathon-adapter",
+	"GoVersion": "go1.3",
 	"Deps": [
 		{
 			"ImportPath": "github.com/CenturyLinkLabs/gomarathon",
 			"Rev": "b005c4f93790b93b46687561cdc2f7c31cf08640"
+		},
+		{
+			"ImportPath": "github.com/CenturyLinkLabs/panamax-marathon-adapter/api",
+			"Rev": "9c75e6468c3e84c3808ce1c889ce2e6afa04eee0"
+		},
+		{
+			"ImportPath": "github.com/CenturyLinkLabs/panamax-marathon-adapter/marathon",
+			"Rev": "9c75e6468c3e84c3808ce1c889ce2e6afa04eee0"
 		},
 		{
 			"ImportPath": "github.com/codegangsta/inject",
@@ -15,10 +23,6 @@
 			"ImportPath": "github.com/codegangsta/martini",
 			"Comment": "v1.0",
 			"Rev": "49411a5b646861ad29a6ddd5351717a0a9c49b94"
-		},
-		{
-			"ImportPath": "github.com/satori/go.uuid",
-			"Rev": "3beb4ac9036769bac8fea7ee8d686280d7ff02ea"
 		}
 	]
 }

--- a/api/server.go
+++ b/api/server.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	API_VERSION = "v1"
-	VERSION = "0.1.0"
+	VERSION     = "0.1.0"
 )
 
 type martiniServer struct {

--- a/marathon/adapter.go
+++ b/marathon/adapter.go
@@ -2,6 +2,7 @@
 package marathon // import "github.com/CenturyLinkLabs/panamax-marathon-adapter/marathon"
 
 import (
+	"crypto/rand"
 	"fmt"
 	"log"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/CenturyLinkLabs/gomarathon"
 	"github.com/CenturyLinkLabs/panamax-marathon-adapter/api"
-	"github.com/satori/go.uuid"
 )
 
 // Creates a client connection to Marathon on the provided endpoint.
@@ -51,8 +51,8 @@ type gomarathonClientAbstractor interface {
 }
 
 type marathonAdapter struct {
-	client      gomarathonClientAbstractor
-	conv        PanamaxServiceConverter
+	client gomarathonClientAbstractor
+	conv   PanamaxServiceConverter
 }
 
 func NewMarathonAdapter(endpoint string) *marathonAdapter {
@@ -151,9 +151,12 @@ func (m *marathonAdapter) findDependencies(services []*api.Service) map[string]i
 
 func (m *marathonAdapter) generateUniqueUID() string {
 
-	// take first stanza of generated UID
-	uid := strings.Split(fmt.Sprintf("%s", uuid.NewV4()), "-")[0]
+	//generate a random number expressed in hex
+	num := make([]byte, 4)
+	rand.Read(num)
+	uid := fmt.Sprintf("%X", num)
 
+	fmt.Println("in generateUniqueID")
 	if _, err := m.client.GetGroup(uid); err == nil {
 		uid = m.generateUniqueUID()
 	}

--- a/marathon/adapter_test.go
+++ b/marathon/adapter_test.go
@@ -49,6 +49,15 @@ func (c *mockClient) CreateGroup(group *gomarathon.Group) (*gomarathon.Response,
 	}
 }
 
+func (c *mockClient) GetGroup(id string) (*gomarathon.Response, error) {
+	args := c.Mock.Called(id)
+	if len(args) == 1 {
+		return args.Get(0).(*gomarathon.Response), nil
+	} else {
+		return args.Get(0).(*gomarathon.Response), args.Error(1)
+	}
+}
+
 func (c *mockClient) DeleteApp(id string) (*gomarathon.Response, error) {
 	args := c.Mock.Called(id)
 	if len(args) == 1 {
@@ -120,7 +129,6 @@ func setup() (*mockClient, *mockConverter, *marathonAdapter) {
 	adapter := new(marathonAdapter)
 	adapter.client = testClient
 	adapter.conv = testConverter
-	adapter.generateUID = func() string { return "pmx" }
 
 	return testClient, testConverter, adapter
 }

--- a/marathon/deployer_test.go
+++ b/marathon/deployer_test.go
@@ -1,9 +1,12 @@
 package marathon
 
 import (
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/CenturyLinkLabs/gomarathon"
+	"github.com/CenturyLinkLabs/panamax-marathon-adapter/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,6 +30,7 @@ func testTimeoutState(deployment *deployment, ctx *context) stateFn {
 
 func TestGroupDeployment(t *testing.T) {
 	var deployment1, deployment2 deployment
+	var deployer MarathonDeployer
 
 	deployment1.name = "slowApp"
 	deployment1.startingState = testSuccessState
@@ -36,13 +40,14 @@ func TestGroupDeployment(t *testing.T) {
 	myGroup := new(deploymentGroup)
 	myGroup.deployments = []deployment{deployment1, deployment2}
 
-	deployGroup(myGroup, timeoutDuration)
+	deployer.DeployGroup(myGroup, timeoutDuration)
 
 	assert.Equal(t, true, myGroup.Done())
 }
 
 func TestFailedGroupDeployment(t *testing.T) {
 	var deployment1, deployment2 deployment
+	var deployer MarathonDeployer
 
 	deployment1.name = "slowApp"
 	deployment1.startingState = testSuccessState
@@ -52,13 +57,14 @@ func TestFailedGroupDeployment(t *testing.T) {
 	myGroup := new(deploymentGroup)
 	myGroup.deployments = []deployment{deployment1, deployment2}
 
-	deployGroup(myGroup, timeoutDuration)
+	deployer.DeployGroup(myGroup, timeoutDuration)
 
 	assert.Equal(t, true, myGroup.Failed())
 }
 
 func TestTimedoutGroupDeployment(t *testing.T) {
 	var deployment1, deployment2 deployment
+	var deployer MarathonDeployer
 
 	deployment1.name = "testApp"
 	deployment1.startingState = testSuccessState
@@ -68,8 +74,24 @@ func TestTimedoutGroupDeployment(t *testing.T) {
 	myGroup := new(deploymentGroup)
 	myGroup.deployments = []deployment{deployment1, deployment2}
 
-	status := deployGroup(myGroup, timeoutDuration)
+	status := deployer.DeployGroup(myGroup, timeoutDuration)
 
 	assert.Equal(t, OK, myGroup.deployments[0].status.code)
 	assert.Equal(t, TIMEOUT, status.code)
+}
+
+func TestBuildDeploymentGroup(t *testing.T) {
+	var deployer MarathonDeployer
+	var testClient mockClient
+
+	resp := new(gomarathon.Response)
+	services := make([]*api.Service, 1)
+	services[0] = &api.Service{Name: "foo"}
+
+	deployer.uidGenerator = func() string { return "pmx" }
+
+	testClient.On("GetGroup", "pmx").Return(resp, errors.New("test"))
+	group := deployer.BuildDeploymentGroup(services, &testClient)
+
+	assert.Equal(t, "/pmx/foo", group.deployments[0].application.ID)
 }


### PR DESCRIPTION
Instead of using a UUID, use a random number hexdump as the group id.