### PR TITLE
signal deploy go routine to stop when timeout happens

### DIFF
--- a/marathon/states.go
+++ b/marathon/states.go
@@ -29,7 +29,7 @@ func loadDockerVars(ctx *context, reqs map[string]string) map[string]string {
 // requirement gathering state. If the requirements are found then load
 // the docker variables and return the deployment state.
 func requirementState(deployment *deployment, ctx *context) stateFn {
-	log.Printf("Requirements %s", deployment.name)
+	log.Printf("Deployment Requirements: %s", deployment.application.ID)
 	if len(deployment.reqs) == 0 {
 		return deploymentState
 	} else {
@@ -58,8 +58,6 @@ func requirementState(deployment *deployment, ctx *context) stateFn {
 // If the deployment was successful return the post action state.
 // If the deployment failed then set fail code and return nil.
 func deploymentState(deployment *deployment, ctx *context) stateFn {
-	log.Printf("Deploying: %s", deployment.application.ID)
-
 	_, err := deployment.client.CreateApp(deployment.application)
 	time.Sleep(2000 * time.Millisecond)
 	if err != nil {

--- a/marathon/types.go
+++ b/marathon/types.go
@@ -15,7 +15,7 @@ const (
 )
 
 const (
-	DEPLOY_TIMEOUT = time.Minute * 10
+	DEPLOY_TIMEOUT = time.Minute * 1
 )
 
 
@@ -27,13 +27,16 @@ type stateFn func(*deployment, *context) stateFn
 // map of maps. The context is used by the deployment
 // workflow to share data between steps.
 type context struct {
+	signal int
 	values map[string]map[string]string
 }
 
 // The context AddKey function is a helper to insert maps into the
 // context under a provided key.
 func (c *context) AddKey(key string, values map[string]string) {
+	c.signal = OK
 	c.values[key] = values
+
 }
 
 // Creates a new context with empty values.
@@ -93,6 +96,7 @@ func createDeployment(service *api.Service, client gomarathonClientAbstractor) d
 // tasks.
 type deploymentGroup struct {
 	id          string
+	status 	    int
 	deployments []deployment
 }
 


### PR DESCRIPTION
I tried to create a way to communicate to the deploy go routine that the timeout channel was signaled by using the channel itself but struggled with a decent implementation. So i just used the context which was only used for shared values and added a signal flag on it.