### PR TITLE
better method to determine job is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+0.1.1 - 2015-02-12
+------------------
+
+BUG: Fix issue where deployment may return false success
+
+
 0.1.0 - 2015-02-06
 ------------------
 
 Initial beta release
+
+
+

--- a/marathon/states.go
+++ b/marathon/states.go
@@ -110,8 +110,8 @@ func postActionState(deployment *deployment, ctx *context) stateFn {
 	application := deployment.application
 	_, name := splitServiceId(application.ID[1:], "/")
 
-	res, _ := deployment.client.GetAppTasks(application.ID)
-	if len(res.Tasks) != 0 {
+	res, _ := deployment.client.GetApp(application.ID)
+	if res.App.TasksRunning > 0 {
 		log.Printf("Post Deployment: %s", deployment.application.ID)
 		appRes, err := deployment.client.GetApp(application.ID)
 		if err != nil {
@@ -132,5 +132,6 @@ func postActionState(deployment *deployment, ctx *context) stateFn {
 
 		return nil
 	}
+	time.Sleep(2000 * time.Millisecond)
 	return postActionState
 }

--- a/marathon/states_test.go
+++ b/marathon/states_test.go
@@ -133,6 +133,7 @@ func TestPostAction(t *testing.T) {
 	var svc = api.Service{Name: "Foo", Command: "echo"}
 	var ctx = NewContext()
 	var app = setupTestApplication()
+	app.TasksRunning = 1
 
 	deployment := createDeployment(&svc, client)
 	task.Host = "1.2.3.4"
@@ -141,7 +142,6 @@ func TestPostAction(t *testing.T) {
 	resp.Tasks = []*gomarathon.Task{task}
 	deployment.name = "TestEmpty"
 
-	client.On("GetAppTasks", deployment.application.ID).Return(resp)
 	client.On("GetApp", deployment.application.ID).Return(resp)
 	postActionState(&deployment, &ctx)
 

--- a/marathon/types.go
+++ b/marathon/types.go
@@ -2,6 +2,7 @@ package marathon
 
 import (
 	"time"
+	"log"
 
 	"github.com/CenturyLinkLabs/gomarathon"
 	"github.com/CenturyLinkLabs/panamax-marathon-adapter/api"
@@ -79,6 +80,7 @@ func createDeployment(service *api.Service, client gomarathonClientAbstractor) d
 	var reqs = make(map[string]string)
 	links := service.Links
 	for i := range links {
+		log.Printf("Linking: %s with Alias: %s", links[i].Name, links[i].Alias)
 		reqs[links[i].Name] = links[i].Alias
 	}
 


### PR DESCRIPTION
There is a time when an attempted task is placed on the completed task list. It is removed very quickly but if the len(Tasks) > 0 check happens it may see this invalid state. The tasksRunning attribute on the Application is a better flag. It will only increment after a task has completed.
